### PR TITLE
Add support for EDITOR env variable

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -79,56 +79,62 @@ fn main() {
         }
     };
 
-    let editor_path: String = match fh::read_from_config(Editor.name()) {
-        Ok(file_path) => file_path,
-        Err(_) => {
-            println!("What editor do you want to use for writing down your ideas?");
-            println!("1) vim (/usr/bin/vim)");
-            println!("2) nano (/usr/bin/nano)");
-            println!("3) Other (provide path to binary)");
-            println!();
-            print!("Alternative: ");
-            io::stdout().flush().unwrap();
+    let editor_path_from_env: Option<String> = ::env::var("EDITOR").ok();
 
-            let input_choice: String = read!();
-            // Cast to int to be able to match
-            let editor_choice: u32 = input_choice.parse::<u32>().unwrap();
-            let input_path: String = match editor_choice {
-                1 => s("/usr/bin/vim"),
-                2 => s("/usr/bin/nano"),
-                3 => {
-                    print!("Path to editor binary: ");
-                    io::stdout().flush().unwrap();
-                    let editor_bin_path: String = read!();
-                    editor_bin_path
+    fn editor_path_from_config() -> String {
+        match fh::read_from_config(Editor.name()) {
+            Ok(file_path) => file_path,
+            Err(_) => {
+                println!("What editor do you want to use for writing down your ideas?");
+                println!("1) vim (/usr/bin/vim)");
+                println!("2) nano (/usr/bin/nano)");
+                println!("3) Other (provide path to binary)");
+                println!();
+                print!("Alternative: ");
+                io::stdout().flush().unwrap();
+
+                let input_choice: String = read!();
+                // Cast to int to be able to match
+                let editor_choice: u32 = input_choice.parse::<u32>().unwrap();
+                let input_path: String = match editor_choice {
+                    1 => s("/usr/bin/vim"),
+                    2 => s("/usr/bin/nano"),
+                    3 => {
+                        print!("Path to editor binary: ");
+                        io::stdout().flush().unwrap();
+                        let editor_bin_path: String = read!();
+                        editor_bin_path
+                    }
+                    _ => {
+                        // TODO: Do not fall back, ask user again for options
+                        println!("Invalid option, falling back to vim");
+                        s("/usr/bin/vim")
+                    }
+                };
+
+                if !fh::path_exists(&input_path) {
+                    panic!("Invalid editor path");
                 }
-                _ => {
-                    // TODO: Do not fall back, ask user again for options
-                    println!("Invalid option, falling back to vim");
-                    s("/usr/bin/vim")
+
+                let copy_input_path: String = input_path.clone();
+                match fh::write_to_config(Editor.name(), input_path) {
+                    Ok(_) => copy_input_path,
+                    Err(e) => panic!("Unable to write your editor path to disk: {}", e),
                 }
-            };
-
-            if !fh::path_exists(&input_path) {
-                panic!("Invalid editor path");
-            }
-
-            let copy_input_path: String = input_path.clone();
-            match fh::write_to_config(Editor.name(), input_path) {
-                Ok(_) => copy_input_path,
-                Err(e) => panic!("Unable to write your editor path to disk: {}", e),
             }
         }
-    };
+    }
+
+    let editor_bin_with_args: (String, Vec<String>) = editor_path_from_env.and_then(|p| find_bin(p)).or_else(|| find_bin(editor_path_from_config())).unwrap();
 
     let commit_msg: String = get_commit_msg();
     let readme_path: String = format!("{}/README.md", repo_path);
 
-    match open_editor(&editor_path, &readme_path) {
+    match open_editor(&editor_bin_with_args.0, &editor_bin_with_args.1, &readme_path) {
         Ok(_) => {
             let _ = git_commit_and_push(&repo_path, commit_msg);
         }
-        Err(e) => panic!("Could not open editor at path {}: {}", editor_path, e),
+        Err(e) => panic!("Could not open editor at path {}: {}", editor_bin_with_args.0, e),
     };
 }
 
@@ -153,8 +159,28 @@ fn get_commit_msg() -> String {
     input
 }
 
-fn open_editor(bin_path: &String, file_path: &String) -> Result<(), Error> {
-    match Command::new(bin_path).arg(file_path).status() {
+fn find_bin(editor: String) -> Option<(String, Vec<String>)> {
+    let mut bin_editor_with_args = editor.split(' ');
+    let bin_name = bin_editor_with_args.next().unwrap();
+
+    env::var_os("PATH").and_then(|paths| {
+        env::split_paths(&paths).filter_map(|dir| {
+            let full_path = dir.join(&bin_name);
+            if full_path.is_file() {
+                full_path.to_str().map(|s|String::from(s))
+            } else {
+                None
+            }
+        }).next()
+    }).map(|p| (p, bin_editor_with_args.map(|s| String::from(s)).collect()))
+}
+
+fn open_editor(bin_path: &String, args: &Vec<String>, file_path: &String) -> Result<(), Error> {
+    let mut command: Command = args.iter().fold(Command::new(bin_path), |mut c, i| {
+        c.arg(i);
+        c
+    });
+    match command.arg(file_path).status() {
         Ok(_) => Ok(()),
         Err(e) => {
             println!(
@@ -168,7 +194,7 @@ fn open_editor(bin_path: &String, file_path: &String) -> Result<(), Error> {
 
 /*
  * Helpers
-*/
+ */
 
 fn s(string: &str) -> String {
     string.to_owned()


### PR DESCRIPTION
Instead of saving the editor to a config file, this will try to use EDITOR env variable if it is set to a correct value.