### PR TITLE
Update deprecated method calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ exclude = [
 clap = "~2.27.0"
 text_io = "~0.1.5"
 clippy = {version = "0.0.175", optional = true}
+dirs = "1.0.4"
 
 [features]
 default = []

--- a/src/file_handler.rs
+++ b/src/file_handler.rs
@@ -27,7 +27,7 @@ impl FileSystem for FileHandler {
 }
 
 pub trait ConfigManagement {
-    fn config_dir_create(&self) -> io::Result<()>;
+    fn config_dir_create(&self) -> io::Result<String>;
     fn config_dir_exists(&self) -> bool;
     fn config_read(&self, file: ConfigFile) -> io::Result<String>;
     fn config_write(&self, file: ConfigFile, value: String) -> io::Result<()>;
@@ -39,8 +39,9 @@ pub trait FileManagement {
 }
 
 impl ConfigManagement for FileHandler {
-    fn config_dir_create(&self) -> io::Result<()> {
-        fs::create_dir_all(config_dir_path())
+    fn config_dir_create(&self) -> io::Result<String> {
+        fs::create_dir_all(config_dir_path()).expect("Cannot create directory");
+        Ok(config_dir_path())
     }
 
     fn config_dir_exists(&self) -> bool {
@@ -84,16 +85,16 @@ impl FileManagement for FileHandler {
 
     fn file_rm(&self, file: ConfigFile) -> io::Result<()> {
         let config_file_path = config_path(file);
-        if self.file_exists(&config_file_path) {
-            fs::remove_file(&config_file_path)?;
-            Ok(())
-        } else {
-            let invalid_path = io::Error::new(
+
+        if !self.file_exists(&config_file_path) {
+            return Err(io::Error::new(
                 ErrorKind::NotFound,
                 format!("Path does not exist: {}", config_file_path),
-            );
-            Err(invalid_path)
+            ));
         }
+
+        fs::remove_file(&config_file_path)?;
+        Ok(())
     }
 }
 
@@ -123,10 +124,15 @@ fn config_dir_path() -> String {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use file_handler::ConfigManagement;
+    use file_handler::FileManagement;
     use file_handler::FileSystem;
+    use std::fs;
     use std::io;
 
     struct MockFileSystem;
+    struct MockFileHandler;
 
     impl FileSystem for MockFileSystem {
         fn create_dir(&self, _path: &str) -> io::Result<()> {
@@ -134,11 +140,78 @@ mod tests {
         }
     }
 
+    impl ConfigManagement for MockFileHandler {
+        fn config_dir_create(&self) -> io::Result<String> {
+            Ok(config_dir_path())
+        }
+
+        fn config_dir_exists(&self) -> bool {
+            self.file_exists(&config_dir_path())
+        }
+
+        fn config_read(&self, _file: ConfigFile) -> io::Result<String> {
+            let contents = String::from("~/idea");
+            Ok(contents)
+        }
+
+        fn config_write(&self, _file: ConfigFile, _value: String) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl FileManagement for MockFileHandler {
+        fn file_exists(&self, path: &str) -> bool {
+            fs::metadata(path).is_ok()
+        }
+
+        fn file_rm(&self, _file: ConfigFile) -> io::Result<()> {
+            Ok(())
+        }
+    }
+    // test for FileSystem methods
     #[test]
-    fn it_works() {
+    fn create_dir() {
         let _fs = MockFileSystem {};
-        let actual = _fs.create_dir("irrelevant");
+        let actual = _fs.create_dir("./test");
         println!("{:?}", actual);
         assert!(actual.is_ok());
     }
+
+    // tests for FileHandler methods
+    #[test]
+    fn create_config_dir() {
+        let fh = MockFileHandler {};
+        let dir = fh.config_dir_create().unwrap();
+        assert_eq!(fh.file_exists(&dir), true);
+    }
+
+    #[test]
+    fn check_config_dir_exists() {
+        let fh = MockFileHandler {};
+        let dir = config_dir_path();
+        assert_eq!(fh.file_exists(&dir), true);
+    }
+
+    #[test]
+    fn write_config_file() {
+        let fh = MockFileHandler {};
+        let repo = String::from("~/idea");
+        let write = fh.config_write(ConfigFile::Repo, repo);
+        assert!(write.is_ok());
+    }
+
+    #[test]
+    fn read_config_file() {
+        let fh = MockFileHandler {};
+        let repo = fh.config_read(ConfigFile::Repo).unwrap();
+        assert_eq!(repo, "~/idea");
+    }
+
+    #[test]
+    fn delete_config_file() {
+        let fh = MockFileHandler {};
+        let delete = fh.file_rm(ConfigFile::Repo);
+        assert!(delete.is_ok());
+    }
+
 }

--- a/src/file_handler.rs
+++ b/src/file_handler.rs
@@ -1,4 +1,6 @@
-use std::env;
+extern crate dirs;
+
+use self::dirs::home_dir;
 use std::error::Error;
 use std::fs;
 use std::io;
@@ -104,7 +106,7 @@ fn config_path(file: ConfigFile) -> String {
         ConfigFile::Editor => CONFIG_EDITOR.to_string(),
     };
 
-    match env::home_dir() {
+    match home_dir() {
         Some(location) => format!(
             "{home}/{eureka}/{file_name}",
             home = location.display(),
@@ -116,7 +118,7 @@ fn config_path(file: ConfigFile) -> String {
 }
 
 fn config_dir_path() -> String {
-    match env::home_dir() {
+    match home_dir() {
         Some(home_dir) => format!("{}/{}", home_dir.display(), ".eureka"),
         None => panic!("Could not resolve your $HOME directory"),
     }
@@ -128,7 +130,6 @@ mod tests {
     use file_handler::ConfigManagement;
     use file_handler::FileManagement;
     use file_handler::FileSystem;
-    use std::fs;
     use std::io;
 
     struct MockFileSystem;
@@ -160,8 +161,8 @@ mod tests {
     }
 
     impl FileManagement for MockFileHandler {
-        fn file_exists(&self, path: &str) -> bool {
-            fs::metadata(path).is_ok()
+        fn file_exists(&self, _path: &str) -> bool {
+            true
         }
 
         fn file_rm(&self, _file: ConfigFile) -> io::Result<()> {
@@ -172,7 +173,7 @@ mod tests {
     #[test]
     fn create_dir() {
         let _fs = MockFileSystem {};
-        let actual = _fs.create_dir("./test");
+        let actual = _fs.create_dir("irrelevant");
         println!("{:?}", actual);
         assert!(actual.is_ok());
     }


### PR DESCRIPTION
The env::home_dir() method has been deprecated as of Rust 1.29.0. I've gone ahead and replaced the use of that method with the home_dir() method from the dirs crate. Ideally, this will make usage across different platforms more consistent and less error-prone in the future. 