### PR TITLE
Change editor selection from text to select view

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ clap = "~2.27.0"
 text_io = "~0.1.5"
 clippy = {version = "0.0.175", optional = true}
 dirs = "1.0.4"
+dialoguer = "0.1.0"
 
 [features]
 default = []

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,8 +11,11 @@ extern crate text_io;
 #[macro_use]
 extern crate clap;
 
+extern crate dialoguer;
+
 use clap::ArgMatches;
 use clap::{App, Arg};
+use dialoguer::Select;
 use file_handler::ConfigFile::*;
 use file_handler::ConfigManagement;
 use file_handler::FileHandler;
@@ -80,21 +83,23 @@ fn main() {
     let editor_path: String = match fh.config_read(Editor) {
         Ok(file_path) => file_path,
         Err(_) => {
-            println!("What editor do you want to use for writing down your ideas?");
-            println!("1) vim (/usr/bin/vim)");
-            println!("2) nano (/usr/bin/nano)");
-            println!("3) Other (provide path to binary)");
-            println!();
-            print!("Alternative: ");
-            io::stdout().flush().unwrap();
+            let selections = &[
+                "1) vim (/usr/bin/vim)",
+                "2) nano (/usr/bin/nano)",
+                "3) Other (provide path to binary)",
+            ];
 
-            let input_choice: String = read!();
-            // Cast to int to be able to match
-            let editor_choice: u32 = input_choice.parse::<u32>().unwrap();
-            let input_path: String = match editor_choice {
-                1 => s("/usr/bin/vim"),
-                2 => s("/usr/bin/nano"),
-                3 => {
+            println!("What editor do you want to use for writing down your ideas?");
+            let index = Select::new()
+                .default(0)
+                .items(selections)
+                .interact()
+                .unwrap();
+
+            let input_path: String = match index {
+                0 => s("/usr/bin/vim"),
+                1 => s("/usr/bin/nano"),
+                2 => {
                     print!("Path to editor binary: ");
                     io::stdout().flush().unwrap();
                     let editor_bin_path: String = read!();


### PR DESCRIPTION
I tried changing the selection of the text editor from the input value base of the user to the selection formula, but how about it?

![2018-10-19 9 47 00 mov](https://user-images.githubusercontent.com/23740172/47191835-824c9180-d384-11e8-9f9f-2293db001833.gif)

I am Japanese. Please forgive me in funny English.