### PR TITLE
Seperate .md file per idea.

### DIFF
--- a/src/file_handler.rs
+++ b/src/file_handler.rs
@@ -49,7 +49,19 @@ pub trait IdeaManagement {
 
 impl IdeaManagement for FileHandler {
     fn get_idea_path(&self, repo_path: &String, path: &String) -> io::Result<(String, bool)> {
-        let path: String = format!("{}/{}.md", repo_path, utils::format_idea_filename(path));
+        let folder_path: String = format!("{}/ideas", repo_path);
+        let path: String = format!("{}/{}.md", folder_path, utils::format_idea_filename(path));
+
+        if !self.file_exists(&folder_path.as_str()) {
+            let result = fs::create_dir(&folder_path);
+            if result.is_err() {
+                let error = result.unwrap_err();
+                return Err(io::Error::new(error.kind(), format!("Could not create directory {} : {}",
+                                                  folder_path,
+                                                  error)))
+            }
+        }
+
         if !self.file_exists(&path.as_str()) {
             match fs::File::create(&path) {
                 Ok(_) => Ok((path, true)),
@@ -75,7 +87,8 @@ impl IdeaManagement for FileHandler {
                                                     .expect("Failed to get remote url"))
                                      .expect("Failed to convert url string").replace("\n", "");
 
-                match file.write(format!("## [{}]({}/blob/master/{}.md)\n",
+                // TODO: Branches?
+                match file.write(format!("## [{}]({}/blob/master/ideas/{}.md)\n",
                                        commit_msg,
                                        git_url,
                                        utils::format_idea_filename(commit_msg))

--- a/src/file_handler.rs
+++ b/src/file_handler.rs
@@ -40,6 +40,21 @@ pub trait FileManagement {
     fn file_rm(&self, file: ConfigFile) -> io::Result<()>;
 }
 
+pub trait IdeaManagement {
+    fn get_idea_path(&self, path: &String) -> String;
+}
+
+impl IdeaManagement for FileHandler {
+    fn get_idea_path(&self, repo_path: &String, path: &String) -> String {
+        let path: String = format!("{}/{}.md", repo_path, utils::format_idea_filename(path));
+        if !self.file_exists(&path.as_str()) {
+            fs::File::create(path).unwrap_or_else( panic!("Could not create file {} : {}", path, e) )
+        }
+
+        path
+    }
+}
+
 impl ConfigManagement for FileHandler {
     fn config_dir_create(&self) -> io::Result<String> {
         fs::create_dir_all(config_dir_path()).expect("Cannot create directory");

--- a/src/git.rs
+++ b/src/git.rs
@@ -4,16 +4,17 @@ pub mod git {
     use utils::utils;
 
     pub fn git_commit_and_push(repo_path: &String, msg: String) -> Result<()> {
-        git_add(repo_path)
+        git_add(repo_path, &msg)
             .and(git_commit(repo_path, msg))
             .and(git_push(repo_path))
     }
 
-    fn git_add(repo_path: &String) -> Result<()> {
+    fn git_add(repo_path: &String, commit_msg: &String) -> Result<()> {
         match Command::new(git())
             .args(default_args(repo_path).iter())
             .arg("add")
             .arg("./README.md")
+            .arg(format!("./{}.md", utils::format_idea_filename(commit_msg)))
             .status()
         {
             Ok(_) => Ok(()),
@@ -61,6 +62,17 @@ pub mod git {
                 Err(e)
             }
         }
+    }
+
+    pub fn get_repo_url(repo_path: &String) -> Result<Vec<u8>> {
+        Ok(Command::new(git())
+               .args(default_args(repo_path).iter())
+               .arg("config")
+               .arg("--get")
+               .arg("remote.origin.url")
+               .output()
+               .expect("Could not get remote url.")
+               .stdout)
     }
 
     fn git() -> String {

--- a/src/git.rs
+++ b/src/git.rs
@@ -14,7 +14,7 @@ pub mod git {
             .args(default_args(repo_path).iter())
             .arg("add")
             .arg("./README.md")
-            .arg(format!("./{}.md", utils::format_idea_filename(commit_msg)))
+            .arg(format!("./ideas/{}.md", utils::format_idea_filename(commit_msg)))
             .status()
         {
             Ok(_) => Ok(()),

--- a/src/git.rs
+++ b/src/git.rs
@@ -14,7 +14,10 @@ pub mod git {
             .args(default_args(repo_path).iter())
             .arg("add")
             .arg("./README.md")
-            .arg(format!("./ideas/{}.md", utils::format_idea_filename(commit_msg)))
+            .arg(format!(
+                "./ideas/{}.md",
+                utils::format_idea_filename(commit_msg)
+            ))
             .status()
         {
             Ok(_) => Ok(()),
@@ -66,13 +69,13 @@ pub mod git {
 
     pub fn get_repo_url(repo_path: &String) -> Result<Vec<u8>> {
         Ok(Command::new(git())
-               .args(default_args(repo_path).iter())
-               .arg("config")
-               .arg("--get")
-               .arg("remote.origin.url")
-               .output()
-               .expect("Could not get remote url.")
-               .stdout)
+            .args(default_args(repo_path).iter())
+            .arg("config")
+            .arg("--get")
+            .arg("remote.origin.url")
+            .output()
+            .expect("Could not get remote url.")
+            .stdout)
     }
 
     fn git() -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,7 +138,7 @@ fn main() {
         // If getting the idea path failed then panic.
         let (idea_path, is_new_idea) = match idea_path {
             Ok((path, is_new_idea)) => (path, is_new_idea),
-            Err(e) => panic!("Could not get idea_path : {}", e)
+            Err(e) => panic!("Could not get idea_path : {}", e),
         };
 
         match open_editor(&editor_path, &idea_path) {
@@ -146,11 +146,11 @@ fn main() {
                 // If the idea already exists we dont need a new entry in the readme
                 if is_new_idea {
                     fh.add_idea_to_readme(&readme_path, &commit_msg, &repo_path)
-                      .expect(&format!("Could not write to {}", &readme_path));
+                        .expect(&format!("Could not write to {}", &readme_path));
                 }
 
                 let _ = git_commit_and_push(&repo_path, commit_msg);
-            },
+            }
             Err(e) => panic!("Could not open editor at path {}: {}", editor_path, e),
         };
     } else {
@@ -177,7 +177,7 @@ fn get_commit_msg() -> String {
     println!("Idea commit subject: ");
     let mut input = String::new();
     io::stdin().read_line(&mut input).unwrap();
-    input.replace("\n","")
+    input.replace("\n", "")
 }
 
 fn open_editor(bin_path: &String, file_path: &String) -> Result<(), Error> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,8 +132,9 @@ fn main() {
     if !first_time {
         let commit_msg: String = get_commit_msg();
         let readme_path: String = format!("{}/README.md", repo_path);
+        let idea_path: String = format!("{}/{}.md", repo_path, utils::utils::format_idea_filename(&commit_msg));
 
-        match open_editor(&editor_path, &readme_path) {
+        match open_editor(&editor_path, &idea_path) {
             Ok(_) => {
                 let _ = git_commit_and_push(&repo_path, commit_msg);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,10 +132,12 @@ fn main() {
     if !first_time {
         let commit_msg: String = get_commit_msg();
         let readme_path: String = format!("{}/README.md", repo_path);
-        let idea_path: String = format!("{}/{}.md", repo_path, utils::utils::format_idea_filename(&commit_msg));
+        let idea_path = fh.get_idea_path(repo_path, commit_msg);
 
         match open_editor(&editor_path, &idea_path) {
             Ok(_) => {
+                        // TODO: append to readme
+                        //       add files and commit
                 let _ = git_commit_and_push(&repo_path, commit_msg);
             }
             Err(e) => panic!("Could not open editor at path {}: {}", editor_path, e),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,4 +13,9 @@ pub mod utils {
         }
         false
     }
+
+    pub fn format_idea_filename(idea: &String) -> String  {
+        idea.replace(" ", "_")
+            .to_uppercase()
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -14,8 +14,7 @@ pub mod utils {
         false
     }
 
-    pub fn format_idea_filename(idea: &String) -> String  {
-        idea.replace(" ", "_")
-            .to_uppercase()
+    pub fn format_idea_filename(idea: &String) -> String {
+        idea.replace(" ", "_").to_uppercase()
     }
 }


### PR DESCRIPTION
This pull requests implements the idea proposed in Issue [#6 ](https://github.com/simeg/eureka/issues/6). When creating a new idea, the commit message is appended to the README.md in the form:

`## [<commit_msg>](www.github.com/<username>/<repo>/blob/master/ideas/<commit_msg>)`, 

and creates a file in an 'ideas' folder with the name `<commit_msg>.md`.

![](https://i.imgur.com/1OIDyxC.png)

![](https://i.imgur.com/taNVMBT.png)
