### PR TITLE
Fix to push with branch name from config

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -41,12 +41,10 @@ impl Git {
         )
     }
 
-    pub fn push(&self) -> Result<(), git2::Error> {
+    pub fn push(&self, branch_name: String) -> Result<(), git2::Error> {
         let mut remote = self.repo.find_remote("origin").unwrap();
 
         remote.connect_auth(Direction::Push, Some(self.get_callbacks()), None)?;
-
-        let branch_name = "master";
 
         let mut options = PushOptions::default();
         options.remote_callbacks(self.get_callbacks());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,9 @@ where
         self.printer.println("Added and committed!");
 
         self.printer.println("Pushing your new idea..");
-        git.push().expect("Something went wrong pushing");
+
+        let branch_name = self.fh.config_read(Branch).unwrap();
+        git.push(branch_name).expect("Something went wrong pushing");
         self.printer.println("Pushed!");
     }
 


### PR DESCRIPTION
 A small change to use the configured branch name.
Closes #70 