### PR TITLE
Commit and push to stored branch name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,13 +122,20 @@ where
 
         self.printer
             .println("Adding and committing your new idea..");
+        let branch_name = self
+            .fh
+            .config_read(Branch)
+            .unwrap_or_else(|_| panic!("Branch config is missing (should never end up here"));
+        git.checkout_branch(&*branch_name)
+            .expect("Something went wrong checking out branch");
         git.add()
             .and_then(|_| git.commit(commit_subject))
             .expect("Something went wrong adding or committing");
         self.printer.println("Added and committed!");
 
         self.printer.println("Pushing your new idea..");
-        git.push().expect("Something went wrong pushing");
+        git.push(&*branch_name)
+            .expect("Something went wrong pushing");
         self.printer.println("Pushed!");
     }
 


### PR DESCRIPTION
Before this change eureka would store the branch name on setup but
wouldn't commit nor push to the branch. This commit fixes that.

Fixes #70.