### PR TITLE
updating a readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ echo 'alias idea="eureka"' >> ~/.bashrc
 This repo uses a Makefile as an interface for common operations.
 
 1) Do code changes
-2) Run `make build link` to build the project and create a symlink from the built binary to the root
+2) Run `make link` to build the project and create a symlink from the built binary to the root
    of the project
 3) Run `./eureka` to execute the binary with your changes
 4) Profit :star:


### PR DESCRIPTION
The readme mentions 
> 1) Do code changes
> 2) Run `make link` to build the project and create a symlink from the built binary to the root
   of the project
> ...

But per the `Makefile`, there's no `make build link` command, just `make link`.  This change updates the readme to say that :) 